### PR TITLE
remove add_code_with_parameters and use optional parameters

### DIFF
--- a/biscuit_test.py
+++ b/biscuit_test.py
@@ -47,6 +47,10 @@ def test_biscuit_builder():
     builder.add_check(Check("check if fact($var, {f}) trusting {pubkey}", { 'f': True }, { 'pubkey': pubkey }));
     builder.merge(BlockBuilder('builder(true);'))
 
+    builder.add_code("add_code(true);")
+    builder.add_code("add_code(true, {f});", { 'f': True})
+    builder.add_code("check if add_code(true, {f}) trusting {pubkey};", { 'f': True}, { 'pubkey': pubkey })
+
     assert repr(builder) == """// no root key id set
 string("1234");
 int(1);
@@ -57,11 +61,14 @@ set([2, "Test", 2023-04-29T01:00:00Z, true]);
 fact(false);
 fact(true);
 builder(true);
+add_code(true);
+add_code(true, true);
 head($var) <- fact($var, true);
 head($var) <- fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 check if true trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 check if fact($var, true);
 check if fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
+check if add_code(true, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 """
 
     builder.build(kp.private_key)
@@ -98,6 +105,9 @@ def test_block_builder():
     builder.add_check(Check("check if fact($var, {f})", { 'f': True }));
     builder.add_check(Check("check if fact($var, {f}) trusting {pubkey}", { 'f': True }, { 'pubkey': pubkey }));
     builder.merge(BlockBuilder('builder(true);'))
+    builder.add_code("add_code(true);")
+    builder.add_code("add_code(true, {f});", { 'f': True})
+    builder.add_code("check if add_code(true, {f}) trusting {pubkey};", { 'f': True}, { 'pubkey': pubkey })
 
     assert repr(builder) == """string("1234");
 int(1);
@@ -107,11 +117,14 @@ datetime(2023-04-03T10:00:00Z);
 fact(false);
 fact(true);
 builder(true);
+add_code(true);
+add_code(true, true);
 head($var) <- fact($var, true);
 head($var) <- fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 check if true trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 check if fact($var, true);
 check if fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
+check if add_code(true, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 """
 
 def test_authorizer_builder():
@@ -150,6 +163,9 @@ def test_authorizer_builder():
     builder.add_policy(Policy("allow if fact($var, {f}) trusting {pubkey}", { 'f': True}, { 'pubkey': pubkey }))
     builder.merge_block(BlockBuilder('builder(true);'))
     builder.merge(Authorizer('builder(false);'))
+    builder.add_code("add_code(true);")
+    builder.add_code("add_code(true, {f});", { 'f': True})
+    builder.add_code("check if add_code(true, {f}) trusting {pubkey};", { 'f': True}, { 'pubkey': pubkey })
 
     try:
         builder.authorize()
@@ -158,6 +174,8 @@ def test_authorizer_builder():
 
     assert repr(builder) == """// Facts:
 // origin: authorizer
+add_code(true);
+add_code(true, true);
 bool(true);
 builder(false);
 builder(true);
@@ -178,6 +196,7 @@ head($var) <- fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe79
 check if true trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 check if fact($var, true);
 check if fact($var, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
+check if add_code(true, true) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189;
 
 // Policies:
 allow if true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,11 +98,7 @@ impl PyBiscuitBuilder {
     ) -> PyResult<PyBiscuitBuilder> {
         let mut builder = PyBiscuitBuilder(builder::BiscuitBuilder::new());
         if let Some(source) = source {
-            builder.add_code_with_parameters(
-                &source,
-                parameters.unwrap_or_default(),
-                scope_parameters.unwrap_or_default(),
-            )?;
+            builder.add_code(&source, parameters, scope_parameters)?;
         }
         Ok(builder)
     }
@@ -123,17 +119,6 @@ impl PyBiscuitBuilder {
         ))
     }
 
-    /// Add code to the builder. This code snippet cannot contain parameters. See
-    /// `add_code_with_parameters` if you need to provide parameters
-    ///
-    /// :param source: a datalog snippet that will be added to the builder
-    /// :type source: str
-    pub fn add_code(&mut self, source: &str) -> PyResult<()> {
-        self.0
-            .add_code(source)
-            .map_err(|e| DataLogError::new_err(e.to_string()))
-    }
-
     /// Add code to the builder, using the provided parameters.
     ///
     /// :param source: a datalog snippet
@@ -142,25 +127,33 @@ impl PyBiscuitBuilder {
     /// :type parameters: dict, optional
     /// :param scope_parameters: public keys for the public key parameters in the datalog snippet
     /// :type scope_parameters: dict, optional
-    pub fn add_code_with_parameters(
+    pub fn add_code(
         &mut self,
         source: &str,
-        parameters: HashMap<String, PyTerm>,
-        scope_parameters: HashMap<String, PyPublicKey>,
+        parameters: Option<HashMap<String, PyTerm>>,
+        scope_parameters: Option<HashMap<String, PyPublicKey>>,
     ) -> PyResult<()> {
         let mut params = HashMap::new();
 
-        for (k, raw_value) in parameters {
-            params.insert(k, raw_value.to_term()?);
+        if let Some(parameters) = parameters {
+            for (k, v) in parameters {
+                params.insert(k, v.to_term()?);
+            }
         }
 
-        let scope_parameters = scope_parameters
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.0))
-            .collect();
+        let scope_params;
+
+        if let Some(scope_parameters) = scope_parameters {
+            scope_params = scope_parameters
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.0))
+                .collect();
+        } else {
+            scope_params = HashMap::new();
+        }
 
         self.0
-            .add_code_with_params(source, params, scope_parameters)
+            .add_code_with_params(source, params, scope_params)
             .map_err(|e| DataLogError::new_err(e.to_string()))
     }
 
@@ -355,11 +348,7 @@ impl PyAuthorizer {
     ) -> PyResult<PyAuthorizer> {
         let mut builder = PyAuthorizer(Authorizer::new());
         if let Some(source) = source {
-            builder.add_code_with_parameters(
-                &source,
-                parameters.unwrap_or_default(),
-                scope_parameters.unwrap_or_default(),
-            )?;
+            builder.add_code(&source, parameters, scope_parameters)?;
         }
         Ok(builder)
     }
@@ -372,25 +361,33 @@ impl PyAuthorizer {
     /// :type parameters: dict, optional
     /// :param scope_parameters: public keys for the public key parameters in the datalog snippet
     /// :type scope_parameters: dict, optional
-    pub fn add_code_with_parameters(
+    pub fn add_code(
         &mut self,
         source: &str,
-        raw_parameters: HashMap<String, PyTerm>,
-        scope_parameters: HashMap<String, PyPublicKey>,
+        parameters: Option<HashMap<String, PyTerm>>,
+        scope_parameters: Option<HashMap<String, PyPublicKey>>,
     ) -> PyResult<()> {
-        let mut parameters = HashMap::new();
+        let mut params = HashMap::new();
 
-        for (k, raw_value) in raw_parameters {
-            parameters.insert(k, raw_value.to_term()?);
+        if let Some(parameters) = parameters {
+            for (k, v) in parameters {
+                params.insert(k, v.to_term()?);
+            }
         }
 
-        let scope_parameters = scope_parameters
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.0))
-            .collect();
+        let scope_params;
+
+        if let Some(scope_parameters) = scope_parameters {
+            scope_params = scope_parameters
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.0))
+                .collect();
+        } else {
+            scope_params = HashMap::new();
+        }
 
         self.0
-            .add_code_with_params(source, parameters, scope_parameters)
+            .add_code_with_params(source, params, scope_params)
             .map_err(|e| DataLogError::new_err(e.to_string()))
     }
 
@@ -534,11 +531,7 @@ impl PyBlockBuilder {
     ) -> PyResult<PyBlockBuilder> {
         let mut builder = PyBlockBuilder(builder::BlockBuilder::new());
         if let Some(source) = source {
-            builder.add_code_with_parameters(
-                &source,
-                parameters.unwrap_or_default(),
-                scope_parameters.unwrap_or_default(),
-            )?;
+            builder.add_code(&source, parameters, scope_parameters)?;
         }
         Ok(builder)
     }
@@ -592,25 +585,33 @@ impl PyBlockBuilder {
     /// :type parameters: dict, optional
     /// :param scope_parameters: public keys for the public key parameters in the datalog snippet
     /// :type scope_parameters: dict, optional
-    pub fn add_code_with_parameters(
+    pub fn add_code(
         &mut self,
         source: &str,
-        raw_parameters: HashMap<String, PyTerm>,
-        scope_parameters: HashMap<String, PyPublicKey>,
+        parameters: Option<HashMap<String, PyTerm>>,
+        scope_parameters: Option<HashMap<String, PyPublicKey>>,
     ) -> PyResult<()> {
-        let mut parameters = HashMap::new();
+        let mut params = HashMap::new();
 
-        for (k, raw_value) in raw_parameters {
-            parameters.insert(k, raw_value.to_term()?);
+        if let Some(parameters) = parameters {
+            for (k, v) in parameters {
+                params.insert(k, v.to_term()?);
+            }
         }
 
-        let scope_parameters = scope_parameters
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.0))
-            .collect();
+        let scope_params;
+
+        if let Some(scope_parameters) = scope_parameters {
+            scope_params = scope_parameters
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.0))
+                .collect();
+        } else {
+            scope_params = HashMap::new();
+        }
 
         self.0
-            .add_code_with_params(source, parameters, scope_parameters)
+            .add_code_with_params(source, params, scope_params)
             .map_err(|e| DataLogError::new_err(e.to_string()))
     }
 


### PR DESCRIPTION
Python (and pyo3) handle optional parameters very well, so we don't need separated `add_code` and `add_code_with_parameters` (and that's what constructors were already doing, anyway).

`add_code` was not directly covered in the test cases, so i added test cases as well.