### PR TITLE
Make biscuit_auth module init function pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,7 +1273,7 @@ impl PyUnverifiedBiscuit {
 
 /// Main module for the biscuit_auth lib
 #[pymodule]
-fn biscuit_auth(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+pub fn biscuit_auth(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyKeyPair>()?;
     m.add_class::<PyPublicKey>()?;
     m.add_class::<PyPrivateKey>()?;


### PR DESCRIPTION
We have python bindings to both the stock biscuit-auth crate, as well
as our own rust crate that depends on biscuit-auth.  In order for
these to interoperate they all need to be linked together into a
single shared library.  (Or at least, that was the safest way I could
find to do it).

AFAICT python requires that the shared library name match the module
name, so it will not call the module init function in this case.  This
PR makes the `biscuit_auth` module init function `pub` so it can be
called from another crate's module init function.
