### PR TITLE
Remove incorrect @classmethod on constructors

### DIFF
--- a/biscuit_auth.pyi
+++ b/biscuit_auth.pyi
@@ -482,7 +482,6 @@ class PublicKey:
     # :type data: str
     # :return: the public key
     # :rtype: PublicKey
-    @classmethod
     def __new__(cls, data: str) -> PublicKey: ...
 
 # ed25519 private key
@@ -508,7 +507,6 @@ class PrivateKey:
     # :type data: str
     # :return: the private key
     # :rtype: PrivateKey
-    @classmethod
     def __new__(cls, data: str) -> PrivateKey: ...
 
 # A single datalog Fact


### PR DESCRIPTION
This confuses [ty](https://docs.astral.sh/ty/):

```
error[invalid-argument-type]: Argument to bound method `PrivateKey.__new__` is incorrect
   --> conftest.py:118:12
    |
118 |     return PrivateKey(private_key)
    |            ^^^^^^^^^^^^^^^^^^^^^^^ Expected `str`, found `<class 'PrivateKey'>`
    |
info: Method defined here
   --> .venv/lib/python3.13/site-packages/biscuit_auth/__init__.pyi:512:9
    |
512 |     def __new__(cls, data: str) -> PrivateKey: ...
    |         ^^^^^^^ --- Parameter declared here
    |

error[too-many-positional-arguments]: Too many positional arguments to bound method `PrivateKey.__new__`: expected 1, got 2
   --> conftest.py:118:23
    |
118 |     return PrivateKey(private_key)
    |                       ^^^^^^^^^^^
    |
info: Method signature here
   --> .venv/lib/python3.13/site-packages/biscuit_auth/__init__.pyi:512:9
    |
512 |     def __new__(cls, data: str) -> PrivateKey: ...
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
```